### PR TITLE
Fix installerPath var for macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ fi
 
 installerPath="${0%/*}"
 
-cp $installerPath/scdl /usr/local/bin/scdl
+cp "$installerPath"/scdl /usr/local/bin/scdl
 chmod a+rx /usr/local/bin/scdl
 
 echo "Installed!"

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ if [ -d /usr/local/bin/scdl ]; then
 	rm -rf /usr/local/bin/scdl
 fi
 
-installerPath="`dirname "${0}"`"
+installerPath="${0%/*}"
 
 cp $installerPath/scdl /usr/local/bin/scdl
 chmod a+rx /usr/local/bin/scdl

--- a/scdl
+++ b/scdl
@@ -10,6 +10,7 @@ import tempfile
 import shutil
 import urllib
 import argparse
+import ssl
 from mutagen.easyid3 import EasyID3
 from mutagen.mp4 import MP4, MP4Cover
 from mutagen.mp3 import EasyMP3
@@ -26,6 +27,7 @@ kept breaking so freaking often).
 '''
 clientId = "FweeGBOOEOYJWLJN3oEyToGLKhmSz0I7"
 appVersion = "1520423007"
+ssl._create_default_https_context = ssl._create_unverified_context
 
 def main():
     parseStuff()


### PR DESCRIPTION
By default, dirname thingy wouldn't work on macOS upon copy but would show wrong syntax used error. This proposes a fix for macOS.