### PR TITLE
Added last track index flag file support

### DIFF
--- a/scdl
+++ b/scdl
@@ -427,12 +427,20 @@ def downloadRegularPrivate(trackId, soundcloudUrl):
     regularPrivateUrl = requests.get(resolveRegularPrivateUrl)
     regularPrivateUrl = regularPrivateUrl.content
     regularPrivateUrl = json.loads(regularPrivateUrl)
-    privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"] +  "&client_id=" + clientId
-    privateMp3Url = privateMp3Url.replace("https://api-mobi.soundcloud.com","https://api-v2.soundcloud.com")
-    privateMp3Url = requests.get(privateMp3Url)
-    privateMp3Url = privateMp3Url.content
-    privateMp3UrlJson = json.loads(privateMp3Url)
-    privateMp3Url = privateMp3UrlJson["url"]
+    try:
+        privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"]
+        privateMp3Url = privateMp3Url.replace("https://api-mobi.soundcloud.com","https://api-v2.soundcloud.com")
+        privateMp3Url = requests.get(privateMp3Url + "?client_id=" + clientId)
+        privateMp3Url = privateMp3Url.content
+        privateMp3UrlJson = json.loads(privateMp3Url)
+        privateMp3Url = privateMp3UrlJson["url"]
+    except:
+        privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"] +  "&client_id=" + clientId
+        privateMp3Url = privateMp3Url.replace("https://api-mobi.soundcloud.com","https://api-v2.soundcloud.com")
+        privateMp3Url = requests.get(privateMp3Url)
+        privateMp3Url = privateMp3Url.content
+        privateMp3UrlJson = json.loads(privateMp3Url)
+        privateMp3Url = privateMp3UrlJson["url"]
     filename = str(trackId) + ".m3u8"
     urllib.request.urlretrieve(privateMp3Url, filename)
 

--- a/scdl
+++ b/scdl
@@ -428,6 +428,7 @@ def downloadRegularPrivate(trackId, soundcloudUrl):
     regularPrivateUrl = regularPrivateUrl.content
     regularPrivateUrl = json.loads(regularPrivateUrl)
     privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"] +  "&client_id=" + clientId
+    privateMp3Url = privateMp3Url.replace("https://api-mobi.soundcloud.com","https://api-v2.soundcloud.com")
     privateMp3Url = requests.get(privateMp3Url)
     privateMp3Url = privateMp3Url.content
     privateMp3UrlJson = json.loads(privateMp3Url)

--- a/scdl
+++ b/scdl
@@ -32,6 +32,8 @@ kept breaking so freaking often).
 
 clientId = "iZIs9mchVcX5lhVRyQGGAYlNPVldzAoX"
 appVersion = "1574432665"
+lastTrackIndexFilePath = "last_track_index.txt"
+lastTrackIndex = 0
 ssl._create_default_https_context = ssl._create_unverified_context
 if platform.system() == 'Windows':
     pathToCurlWindows = str(Path("./bin/curl.exe").absolute())
@@ -356,7 +358,7 @@ def downloadPremium(trackId):
     Stitch the .m4a together using ffmpeg. Thank God I don't have to do this by hand.
     By the way, ffmpeg hates https so it needs to be whitelisted.
     '''
-    ffmpegCommand = "ffmpeg -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".m4a -loglevel panic"
+    ffmpegCommand = "ffmpeg -y -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".m4a -loglevel panic"
     os.system(ffmpegCommand)
 
 def downloadPremiumPrivate(trackId, soundcloudUrl):
@@ -400,7 +402,7 @@ def downloadPremiumPrivate(trackId, soundcloudUrl):
     Stitch the .m4a together using ffmpeg. Thank God I don't have to do this by hand.
     By the way, ffmpeg hates https so it needs to be whitelisted.
     '''
-    ffmpegCommand = "ffmpeg -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".m4a -loglevel panic"
+    ffmpegCommand = "ffmpeg -y -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".m4a -loglevel panic"
     os.system(ffmpegCommand)
 
 def downloadRegular(trackId, soundcloudUrl):
@@ -417,7 +419,7 @@ def downloadRegular(trackId, soundcloudUrl):
     filename = str(trackId) + ".m3u8"
     urllib.request.urlretrieve(privateMp3Url, filename)
 
-    ffmpegCommand = "ffmpeg -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".mp3 -loglevel panic"
+    ffmpegCommand = "ffmpeg -y -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".mp3 -loglevel panic"
     os.system(ffmpegCommand)
 
 def downloadRegularPrivate(trackId, soundcloudUrl):
@@ -434,7 +436,7 @@ def downloadRegularPrivate(trackId, soundcloudUrl):
     filename = str(trackId) + ".m3u8"
     urllib.request.urlretrieve(privateMp3Url, filename)
 
-    ffmpegCommand = "ffmpeg -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".mp3 -loglevel panic"
+    ffmpegCommand = "ffmpeg -y -protocol_whitelist file,http,https,tcp,tls -i " + str(trackId) + ".m3u8 -c copy " + str(trackId) + ".mp3 -loglevel panic"
     os.system(ffmpegCommand)
 
 def getTags(soundcloudUrl):
@@ -585,9 +587,20 @@ def downloadPlaylist(soundcloudUrl, hqFlag):
         description = ""
 
     changeDirectory(album)
-
-    for index in range(trackCount):
+    
+    if not os.path.exists(lastTrackIndexFilePath):
+        lastTrackIndexFile = open(lastTrackIndexFilePath, 'w+')
+        lastTrackIndex = 0
+        lastTrackIndexFile.write(str(lastTrackIndex))
+    else:
+        lastTrackIndexFile = open(lastTrackIndexFilePath, 'r')
+        lastTrackIndex = int(lastTrackIndexFile.read())
+    
+    for index in range(lastTrackIndex, trackCount):
         downloadSingleTrack(permalinkUrl[index], trackName[index], hqFlag, album)
+        lastTrackIndexFile = open(lastTrackIndexFilePath, 'w')
+        lastTrackIndexFile.write(str(index))
+        lastTrackIndexFile.close()
 
 def getPlaylistId(soundcloudUrl):
     '''

--- a/scdl
+++ b/scdl
@@ -31,7 +31,7 @@ kept breaking so freaking often).
 '''
 
 clientId = "iZIs9mchVcX5lhVRyQGGAYlNPVldzAoX"
-appVersion = "1574432665"
+appVersion = "1575626913"
 lastTrackIndexFilePath = "last_track_index.txt"
 lastTrackIndex = 0
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -427,9 +427,8 @@ def downloadRegularPrivate(trackId, soundcloudUrl):
     regularPrivateUrl = requests.get(resolveRegularPrivateUrl)
     regularPrivateUrl = regularPrivateUrl.content
     regularPrivateUrl = json.loads(regularPrivateUrl)
-    privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"]
-    privateMp3Url = privateMp3Url.replace("https://api-mobi.soundcloud.com","https://api-v2.soundcloud.com")
-    privateMp3Url = requests.get(privateMp3Url + "?client_id=" + clientId)
+    privateMp3Url = regularPrivateUrl["media"]["transcodings"][0]["url"] +  "&client_id=" + clientId
+    privateMp3Url = requests.get(privateMp3Url)
     privateMp3Url = privateMp3Url.content
     privateMp3UrlJson = json.loads(privateMp3Url)
     privateMp3Url = privateMp3UrlJson["url"]


### PR DESCRIPTION
It creates a file 'last_track_index.txt' in the album folder itself and resumes from that index, it is the index of the last song downloaded successfully, so next time when it resumes it says "Already exists" for that song and start downloading from next song. Also, added '-y' flag in 'ffmpeg' so that any residues left for the un-downloaded track will be overwritten.